### PR TITLE
adding submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jsonIncidents2015"]
+	path = jsonIncidents2015
+	url = git@github.com:openpgh/jsonIncidents2015.git

--- a/incidents2geojson.py
+++ b/incidents2geojson.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-
+import os
 from os import path, listdir
 import json
 
-json_dir = path.abspath('../jsonIncidents2015')
+json_dir = path.abspath('jsonIncidents2015')
 files = listdir(json_dir)
 
 def convert2geojson(filepath, filename):


### PR DESCRIPTION
This adds a submodule to the repository from github.com/openpgh/jsonIncidents2015 so the user isn't expected to make two clones.

This also fixes an error by adding `import os` to the top of `incidents2geojson.py`
